### PR TITLE
Fix P2 Subscription: Add DB Migration & Refactor Status Logic

### DIFF
--- a/supabase/migrations/20250523203100_add_subscription_fields_to_profiles.sql
+++ b/supabase/migrations/20250523203100_add_subscription_fields_to_profiles.sql
@@ -1,0 +1,12 @@
+-- supabase/migrations/20250523203100_add_subscription_fields_to_profiles.sql
+
+ALTER TABLE public.profiles
+ADD COLUMN IF NOT EXISTS current_subscription_tier TEXT NULL,
+ADD COLUMN IF NOT EXISTS subscription_active BOOLEAN NOT NULL DEFAULT FALSE,
+ADD COLUMN IF NOT EXISTS subscription_expires_at TIMESTAMPTZ NULL,
+ADD COLUMN IF NOT EXISTS generation_limit INT NULL;
+
+COMMENT ON COLUMN public.profiles.current_subscription_tier IS 'Active subscription tier, e.g., monthly_30, monthly_unlimited. Set by validation function.';
+COMMENT ON COLUMN public.profiles.subscription_active IS 'True if the user has an active subscription. Set by validation function.';
+COMMENT ON COLUMN public.profiles.subscription_expires_at IS 'The actual expiry date of the current subscription from the store. Set by validation function.';
+COMMENT ON COLUMN public.profiles.generation_limit IS 'User-specific base daily generation limit if not subscribed, or a custom limit. Can be overridden by active subscription tier benefits.';


### PR DESCRIPTION
- Created migration `20250523203100_add_subscription_fields_to_profiles.sql` to add essential (previously missing) subscription-related columns to the `profiles` table: `current_subscription_tier`, `subscription_active`, `subscription_expires_at`, and `generation_limit`.
- Refactored `get-generation-status` Supabase function:
    - Aligned daily reset logic with `generate-image-proxy` by using `last_generation_at` and `timezone` (copied helper functions for consistency) instead of a non-existent `resets_at_utc_iso` column.
    - Ensured it correctly reflects generation usage for daily tiers (resetting to 0 for display if a new day has started in user's timezone) without performing the actual daily reset database write (which `generate-image-proxy` handles).
    - Profile updates by `get-generation-status` are now correctly scoped to monthly subscription cycle changes (e.g., for `monthly_30` tier).