### PR TITLE
I've removed two unnecessary TODO comments.

### DIFF
--- a/supabase/functions/validate-purchase-and-update-profile/index.ts
+++ b/supabase/functions/validate-purchase-and-update-profile/index.ts
@@ -4,9 +4,6 @@ import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { create as createJWT } from "https://deno.land/x/djwt@v2.8/mod.ts"; // Example JWT library
 // import { corsHeaders } from '../_shared/cors.ts'; // Removed
 
-// Add Google Play Billing API client
-// @ts-ignore
-// const {GooglePlayBilling} = require('@google-cloud/billing'); // TODO: Find Deno-compatible way to use Google Play Billing
 import { corsHeaders } from '../_shared/cors.ts';
 
 // --- Google API Config (Store securely as environment variables) ---

--- a/visionspark/android/app/build.gradle.kts
+++ b/visionspark/android/app/build.gradle.kts
@@ -30,7 +30,6 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId = "app.visionspark.app"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.


### PR DESCRIPTION
- In `supabase/functions/validate-purchase-and-update-profile/index.ts`, the TODO was for finding a Deno-compatible Google Play Billing library, but the code already uses `fetch` for this purpose.
- In `visionspark/android/app/build.gradle.kts`, the TODO was to specify a unique application ID, but it was already set.